### PR TITLE
Fixes/same participants on the run #7

### DIFF
--- a/internal/mturk/step.go
+++ b/internal/mturk/step.go
@@ -261,6 +261,8 @@ func (s *Session) EndStep(project *ent.Project, run *ent.Run, step *ent.Step, st
 		return s.endMTurkHITStep(ctx, project, run, template, step, stepRun, nextStep, nextStepRun)
 	case stepModel.TypeMTURK_MESSAGE:
 		return s.endMTurkMessageStep(ctx, project, run, template, step, stepRun, nextStep, nextStepRun)
+	case stepModel.TypePARTICIPANT_FILTER:
+		return s.endFilterStep(ctx, project, run, template, step, stepRun, nextStep, nextStepRun)
 	case stepModel.TypeWAIT:
 		return nil
 	default:
@@ -400,7 +402,7 @@ func (s *Session) endMTurkMessageStep(ctx context.Context, project *ent.Project,
 
 	participations, err := stepRun.QueryParticipations().WithParticipant().All(ctx)
 	if err != nil {
-		return errors.New("get participants for msg step failed")
+		return errors.New("get participations for msg step failed")
 	}
 
 	participants := make([]*ent.Participant, len(participations))
@@ -414,6 +416,32 @@ func (s *Session) endMTurkMessageStep(ctx context.Context, project *ent.Project,
 		Save(ctx)
 	if err != nil {
 		return errors.Wrap(err, "push msg step participants to next run")
+	}
+
+	return nil
+}
+
+func (s *Session) endFilterStep(ctx context.Context, project *ent.Project, run *ent.Run, template *ent.Template, step *ent.Step, stepRun *ent.StepRun, nextStep *ent.Step, nextStepRun *ent.StepRun) error {
+	if nextStepRun == nil {
+		return nil
+	}
+
+	participations, err := stepRun.QueryParticipations().WithParticipant().All(ctx)
+	if err != nil {
+		return errors.New("get participations for filter step failed")
+	}
+
+	participants := make([]*ent.Participant, len(participations))
+
+	for i, p := range participations {
+		participants[i] = p.Edges.Participant
+	}
+
+	_, err = nextStepRun.Update().
+		AddParticipants(participants...).
+		Save(ctx)
+	if err != nil {
+		return errors.Wrap(err, "push filter step participants to next run")
 	}
 
 	return nil

--- a/internal/runtime/process.go
+++ b/internal/runtime/process.go
@@ -171,8 +171,6 @@ func (r *runState) startStep(ctx context.Context, startTime time.Time) error {
 				return errors.Wrap(err, "filter step getting previous participation")
 			}
 
-			spew.Dump("prevParticipation123", prevParticipation)
-
 			_, err = r.conn.Client.Participation.Create().
 				SetID(xid.New().String()).
 				SetParticipant(p).

--- a/internal/runtime/process.go
+++ b/internal/runtime/process.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/empiricaly/recruitment/internal/ent"
+	"github.com/empiricaly/recruitment/internal/ent/participation"
 	runModel "github.com/empiricaly/recruitment/internal/ent/run"
 	stepModel "github.com/empiricaly/recruitment/internal/ent/step"
 	steprunModel "github.com/empiricaly/recruitment/internal/ent/steprun"
@@ -163,12 +164,29 @@ func (r *runState) startStep(ctx context.Context, startTime time.Time) error {
 			}
 		}
 
-		_, err = r.currentStepRun.Update().
-			AddParticipants(participants...).
-			Save(ctx)
-		if err != nil {
-			return errors.Wrap(err, "push filter step participants to next run")
+		for _, p := range participants {
+			prevParticipation, err := r.conn.Client.Participation.Query().Where(participation.MturkWorkerID(*p.MturkWorkerID)).First(ctx)
+			if err != nil {
+				log.Error().Err(err).Msg("Filter Participant: getting previous participation")
+				return errors.Wrap(err, "filter step getting previous participation")
+			}
+
+			spew.Dump("prevParticipation123", prevParticipation)
+
+			_, err = r.conn.Client.Participation.Create().
+				SetID(xid.New().String()).
+				SetParticipant(p).
+				SetStepRun(r.currentStepRun).
+				SetMturkWorkerID(*p.MturkWorkerID).
+				SetMturkAssignmentID(prevParticipation.MturkAssignmentID).
+				SetMturkHitID(prevParticipation.MturkHitID).
+				Save(ctx)
+			if err != nil {
+				log.Error().Err(err).Msg("Filter Participant: Creating participation")
+				return errors.Wrap(err, "filter step set participation")
+			}
 		}
+
 	case stepModel.TypeWAIT:
 		return nil
 	default:
@@ -180,13 +198,11 @@ func (r *runState) startStep(ctx context.Context, startTime time.Time) error {
 
 func (r *runState) endStep(ctx context.Context, endTime time.Time) error {
 	switch r.currentStep.Type {
-	case stepModel.TypeMTURK_HIT, stepModel.TypeMTURK_MESSAGE:
+	case stepModel.TypeMTURK_HIT, stepModel.TypeMTURK_MESSAGE, stepModel.TypePARTICIPANT_FILTER:
 		err := r.mturkSession.EndStep(r.project, r.run, r.currentStep, r.currentStepRun, r.nextStep, r.nextStepRun)
 		if err != nil {
 			return errors.Wrap(err, "run mturk for step")
 		}
-	case stepModel.TypePARTICIPANT_FILTER:
-		// noop?
 	case stepModel.TypeWAIT:
 		return nil
 	default:


### PR DESCRIPTION
## Context
#7 

## Fixes 
- [x] Fix same participant on the filter step

## Description
I am not sure about the solution that i applied here. On the startStep, I tried to find the previous participation assignmentID and HITID with the same mTurkWorkerID, and then create a participation (because that both fields are required on participation, i guess). on the endStep, i tried to find the created participation, and then add it to participants again.