### PR TITLE
fix: fix context timeout on assignmentForHit

### DIFF
--- a/internal/mturk/api.go
+++ b/internal/mturk/api.go
@@ -175,32 +175,30 @@ func (s *Session) assignmentsForHit(ctx context.Context, hitID string) (chan *mt
 		go func() {
 			defer close(c)
 
-			for {
-				var nextToken *string
-				params := &mturk.ListAssignmentsForHITInput{
-					AssignmentStatuses: aws.StringSlice([]string{"Approved"}),
-					HITId:              aws.String(hitID),
-					MaxResults:         aws.Int64(100),
-				}
+			var nextToken *string
+			params := &mturk.ListAssignmentsForHITInput{
+				AssignmentStatuses: aws.StringSlice([]string{"Approved"}),
+				HITId:              aws.String(hitID),
+				MaxResults:         aws.Int64(100),
+			}
 
-				if nextToken != nil {
-					params.NextToken = nextToken
-				}
+			if nextToken != nil {
+				params.NextToken = nextToken
+			}
 
-				assignments, err := s.MTurk.ListAssignmentsForHITWithContext(ctx, params)
-				if err != nil {
-					log.Error().Err(err).Msg("list assignments for hit")
-				}
+			assignments, err := s.MTurk.ListAssignmentsForHITWithContext(ctx, params)
+			if err != nil {
+				log.Error().Err(err).Msg("list assignments for hit")
+			}
 
-				for _, assignment := range assignments.Assignments {
-					c <- assignment
-				}
+			for _, assignment := range assignments.Assignments {
+				c <- assignment
+			}
 
-				if assignments.NextToken != nil && *assignments.NextToken != "" {
-					nextToken = assignments.NextToken
-				} else {
-					return
-				}
+			if assignments.NextToken != nil && *assignments.NextToken != "" {
+				nextToken = assignments.NextToken
+			} else {
+				return
 			}
 		}()
 	}


### PR DESCRIPTION
## Issues 

- Context timeout on assignmentForHit
<img width="1247" alt="Screen Shot 2020-12-02 at 05 11 19" src="https://user-images.githubusercontent.com/30768964/100800311-640d5700-3461-11eb-823e-9aeae02d324f.png">

## Description
I found out that var nextToken always be empty on the start of the loop, so when we assign value on end of the loop, it won't affect anything.

![rec1](https://user-images.githubusercontent.com/30768964/100800771-01688b00-3462-11eb-9f52-3b842eb4628e.gif)
