### PR TITLE
fix: allow participants to submit hit before timeout #40

### DIFF
--- a/internal/server/answers.go
+++ b/internal/server/answers.go
@@ -92,10 +92,17 @@ func ginAnswersHandler(s *Server) func(c *gin.Context) {
 				return errors.New("trying to save data on a non-hit step")
 			}
 
-			timeExtension := stepRun.EndedAt.Add(time.Minute * time.Duration(step.HitArgs.Timeout))
-			remainingTime := timeExtension.Sub(time.Now())
-			if stepRun.Status != stepRunModel.StatusRUNNING && remainingTime < 0 {
-				return errors.Errorf("stepRun no longer running, cannot save data (current state: %s)", stepRun.Status.String())
+			if stepRun.StartedAt == nil {
+				return errors.New("stepRun is not running yet, cannot save data")
+			}
+
+			if stepRun.EndedAt != nil {
+				timeExtension := stepRun.EndedAt.Add(time.Hour * 1)
+				remainingTime := timeExtension.Sub(time.Now())
+
+				if remainingTime < 0 {
+					return errors.Errorf("stepRun no longer running, cannot save data (current state: %s)", stepRun.Status.String())
+				}
 			}
 
 			run, err := stepRun.Edges.RunOrErr()

--- a/internal/server/questions.go
+++ b/internal/server/questions.go
@@ -223,12 +223,21 @@ func ginQuestionsHandler(s *Server) func(c *gin.Context) {
 			return
 		}
 
-		timeExtension := stepRun.EndedAt.Add(time.Minute * time.Duration(step.HitArgs.Timeout))
-		remainingTime := timeExtension.Sub(time.Now())
-		if stepRun.Status != stepRunModel.StatusRUNNING && remainingTime < 0 {
-			log.Error().Err(err).Msg("stepRun is done")
+		if stepRun.StartedAt == nil {
+			log.Error().Err(err).Msg("stepRun is not running yet")
 			c.AbortWithStatus(http.StatusNotFound)
 			return
+		}
+
+		if stepRun.EndedAt != nil {
+			timeExtension := stepRun.EndedAt.Add(time.Hour * 1)
+			remainingTime := timeExtension.Sub(time.Now())
+
+			if remainingTime < 0 {
+				log.Error().Err(err).Msg("stepRun has ended")
+				c.AbortWithStatus(http.StatusNotFound)
+				return
+			}
 		}
 
 		run, err := stepRun.Edges.RunOrErr()

--- a/internal/server/questions.go
+++ b/internal/server/questions.go
@@ -223,6 +223,14 @@ func ginQuestionsHandler(s *Server) func(c *gin.Context) {
 			return
 		}
 
+		timeExtension := stepRun.EndedAt.Add(time.Minute * time.Duration(step.HitArgs.Timeout))
+		remainingTime := timeExtension.Sub(time.Now())
+		if stepRun.Status != stepRunModel.StatusRUNNING && remainingTime < 0 {
+			log.Error().Err(err).Msg("stepRun is done")
+			c.AbortWithStatus(http.StatusNotFound)
+			return
+		}
+
 		run, err := stepRun.Edges.RunOrErr()
 		if err != nil {
 			log.Error().Err(err).Msg("get run")


### PR DESCRIPTION
## Fixes

- [x] allow participants to submit hit before the timeout

I tried different approach here, i used the timeout on hitArgs to extend the duration. 